### PR TITLE
build: add dotenv-rails

### DIFF
--- a/photo-review-api/.gitignore
+++ b/photo-review-api/.gitignore
@@ -27,3 +27,4 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+.env*

--- a/photo-review-api/Gemfile
+++ b/photo-review-api/Gemfile
@@ -46,3 +46,6 @@ group :development do
   # gem "spring"
 end
 
+# Use dotenv to load environment variables from .env into ENV in development
+# hide secret keys from Github
+gem "dotenv-rails"

--- a/photo-review-api/Gemfile.lock
+++ b/photo-review-api/Gemfile.lock
@@ -75,6 +75,10 @@ GEM
     debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.12.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -161,6 +165,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   debug
+  dotenv-rails
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.6)


### PR DESCRIPTION
For storing secret keys in .env file, which will be ignored when pushing to github