### PR TITLE
fix: remove duplicate file in git ignore

### DIFF
--- a/photo-review-api/.gitignore
+++ b/photo-review-api/.gitignore
@@ -28,4 +28,3 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 .env*
-.env*


### PR DESCRIPTION
-Error: when reconfiguring Cloudinary, re-added .env file in git ignore.
-Fix: remove .env duplicate