### PR TITLE
fix: make album delete button work an reactive

### DIFF
--- a/photo-review-api/app/controllers/albums_controller.rb
+++ b/photo-review-api/app/controllers/albums_controller.rb
@@ -6,13 +6,17 @@ class AlbumsController < ApplicationController
   # GET /albums
   def index
     @albums = Album.all
-    covers = []
+    results = []
+
     @albums.each do |album|
-      album_cover = album.photos.first.image
-      covers.push(album_cover)
+      album_cover = ''
+      album_cover = album.photos.first.image unless album.photos.first.nil?
+      result = album_result(album, album_cover)
+      results.push(result)
     end
 
-    render json: [@albums, covers]
+    # render json: [@albums, covers]
+    render json: results
   end
 
   # GET /albums/1
@@ -48,6 +52,12 @@ class AlbumsController < ApplicationController
   end
 
   private
+
+  def album_result(album, album_cover)
+    album_result = {}.merge(album.attributes)
+    album_result[:cover] = album_cover
+    album_result
+  end
 
   def set_album
     @album = Album.find(params[:id])

--- a/photo-review-client/src/assets/base.css
+++ b/photo-review-client/src/assets/base.css
@@ -89,6 +89,7 @@ body {
 
 .photo-container {
   aspect-ratio: 1 / 1;
+  object-fit: cover;
   border-width: 1px;
   border-color: rgb(71 85 105);
   cursor: pointer;

--- a/photo-review-client/src/views/Albums.vue
+++ b/photo-review-client/src/views/Albums.vue
@@ -16,14 +16,13 @@
             </div>
           </div>
 
-          <div v-for="(album, i) in albums" :key="i">
-            <div class="w-36 h-46 cursor-pointer">
+          <div v-for="(album, i) in albums" :key="album.id">
+            <div class="relative w-36 h-46 cursor-pointer">
               <RouterLink :to="{ name: 'Album', params: { id: album.id } }">
                 <div class="photo-container flex relative h-36 rounded">
-                  <AdvancedImage :cldImg="getCloudinaryImage(covers[i])" class="object-cover"/>
-                  <font-awesome-icon icon="fa-solid fa-x"
-                    class="absolute top-1 right-1 text-slate-400"
-                    @click="deleteAlbum(album)"
+                  <AdvancedImage v-if="album.cover.length > 0" :cldImg="getCloudinaryImage(album.cover)"
+                    place-holder="predominant-color"
+                    class="object-cover"
                   />
                 </div>
                 <div class="pl-1 text-md truncate text-white">
@@ -33,6 +32,10 @@
                   Expire: {{ album.expiry_date }}
                 </div>
               </RouterLink>
+              <font-awesome-icon icon="fa-solid fa-x"
+                class="absolute top-1 right-1 z-50 text-slate-400"
+                @click="deleteAlbum(album)"
+              />
             </div>
           </div>
         </div>
@@ -49,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { onBeforeMount, ref } from 'vue';
 import { RouterLink } from 'vue-router';
 import axios from 'axios';
 import { Cloudinary } from '@cloudinary/url-gen';
@@ -60,17 +63,17 @@ import AlbumCreate from '../components/AlbumCreate.vue';
 interface Album {
   id: number,
   name: string,
-  expiry_date: Date
+  expiry_date: Date,
+  cover: string
 }
 
 let albums = ref<Album[]>([]);
-let covers = ref<string[]>([]);
-onMounted(async () => {
+onBeforeMount(async () => {
   await axios
     .get('http://localhost:3000/albums')
     .then((response) => {
-      albums.value = response.data[0];
-      covers.value = response.data[1];
+      console.log('all albums', response.data)
+      albums.value = response.data.reverse();
     }).catch((error) => {
       console.log(error);
     })
@@ -95,8 +98,6 @@ const deleteAlbum = async(album: Album) => {
     .delete('http://localhost:3000/albums/' + album.id)
     .then((response) => {
       console.log(response);
-      // find the album that is changed
-      // update the album in the frontend
       const index = albums.value.findIndex((alb: Album) => alb.id === album.id);
       albums.value.splice(index, 1);
     }).catch((error) => {


### PR DESCRIPTION
- Error: clicking on album delete button navigated to the album instead of deletion.

Issue (not error, but cumbersome): 
- Album displays a cover, which is the first of all the album's photos. Album model does not store (nor does it need to have) the cover, so we need to find a way to send the cover back with the model. 
- Rails does not have a viewmodel like .NET. Therefore, my original solution was to send to frontend an array with two items [albums, covers]. As a result, in frontend, the only link between photo cover and album is their index. This can be broken easily when am album is deleted and Vue reacts to index change, leading to wrong display of cover.
- Solution: produce a Rail "viewmodel" by shallow-copying the album, add property cover, and send to frontend.