### PR TITLE
fix: make album component reactive to new album addition

### DIFF
--- a/photo-review-client/src/components/AlbumCreate.vue
+++ b/photo-review-client/src/components/AlbumCreate.vue
@@ -45,7 +45,7 @@ const props = defineProps({
   }
 })
 
-const $emit = defineEmits(['closeCreateAlbum', 'addNewAlbum']);
+const $emit = defineEmits(['closeCreateAlbum', 'addedNewAlbum']);
 
 const albumName = ref('');
 const albumExpiryDate = ref('');
@@ -59,8 +59,8 @@ const createAlbum = async() => {
       invitees: invitees.value
     })
     .then((response) => {
-      props.albums.push(response.data);
       closeCreateAlbum();
+      $emit('addedNewAlbum', response.data);
     }).catch((error) => {
       console.log(error);
     })

--- a/photo-review-client/src/views/Albums.vue
+++ b/photo-review-client/src/views/Albums.vue
@@ -45,6 +45,7 @@
     <AlbumCreate v-if="isCreatingAlbum"
       :albums="albums"
       @closeCreateAlbum="isCreatingAlbum = false"
+      @addedNewAlbum="(newAlbum) => addAlbum(newAlbum)"
       class="absolute top-[-200px] left-0 w-full z-10"
     >
     </AlbumCreate>
@@ -52,7 +53,7 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeMount, ref } from 'vue';
+import { computed, onBeforeMount, ref } from 'vue';
 import { RouterLink } from 'vue-router';
 import axios from 'axios';
 import { Cloudinary } from '@cloudinary/url-gen';
@@ -67,16 +68,18 @@ interface Album {
   cover: string
 }
 
-let albums = ref<Album[]>([]);
+let albumsData = ref<Album[]>([]);
 onBeforeMount(async () => {
   await axios
     .get('http://localhost:3000/albums')
     .then((response) => {
-      console.log('all albums', response.data)
-      albums.value = response.data.reverse();
+      albumsData.value = response.data.reverse();
     }).catch((error) => {
       console.log(error);
     })
+});
+const albums = computed(() => {
+  return albumsData.value;
 });
 
 const cld = new Cloudinary({
@@ -97,12 +100,19 @@ const deleteAlbum = async(album: Album) => {
   await axios
     .delete('http://localhost:3000/albums/' + album.id)
     .then((response) => {
-      console.log(response);
-      const index = albums.value.findIndex((alb: Album) => alb.id === album.id);
-      albums.value.splice(index, 1);
+      removeAlbum(album.id)
     }).catch((error) => {
       console.log(error);
     })
+}
+const removeAlbum = (albumId: number) => {
+  const index = albumsData.value.findIndex((alb: Album) => alb.id === albumId);
+  albumsData.value.splice(index, 1);
+}
+
+const addAlbum = (album: Album) => {
+  album.cover = '';
+  albumsData.value.unshift(album);
 }
 </script>
 


### PR DESCRIPTION
- Error: after clicking save new album, new album window stayed open, console log error concerning the album cover.
- Cause: album sent from backend does not have cover. Frontend cannot display album with no cover data, so it caused error.
- Solution: after saving new album, manually add property cover as an empty string.

- Note: to save api calls, I decide not to fetch all the albums every time adding or deleting an album. Instead, I changed the frontend albums array. This approach is faster and saves traffic, but may lag behind if someone never refreshes their page. This is fine with this app, since the album is not constantly updated anyway.