### PR TITLE
feat: show progress for image process

### DIFF
--- a/photo-review-api/app/controllers/photos_controller.rb
+++ b/photo-review-api/app/controllers/photos_controller.rb
@@ -32,7 +32,7 @@ class PhotosController < ApplicationController
 
     photo_params[:files].each do |file|
       upload = create_new_upload(file.original_filename)
-      
+
       processed_image = ImageProcessor.call(file, photo_params[:upload_option], upload.id)
       photo = make_new_photo(processed_image)
       if photo.save

--- a/photo-review-api/app/controllers/uploads_controller.rb
+++ b/photo-review-api/app/controllers/uploads_controller.rb
@@ -85,6 +85,6 @@ class UploadsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def upload_params
-    params.require(:upload).permit(:name, :progress, :album_id, :files, :batch)
+    params.require(:upload).permit(:name, :progress, :album_id, :files)
   end
 end

--- a/photo-review-api/app/controllers/uploads_controller.rb
+++ b/photo-review-api/app/controllers/uploads_controller.rb
@@ -85,6 +85,6 @@ class UploadsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def upload_params
-    params.require(:upload).permit(:name, :progress, :album_id, :files)
+    params.require(:upload).permit(:name, :progress, :album_id, :files, :batch)
   end
 end

--- a/photo-review-api/app/services/image_processor.rb
+++ b/photo-review-api/app/services/image_processor.rb
@@ -95,7 +95,8 @@ class ImageProcessor < ApplicationService
   end
 
   def image_uses_magicload(file_name)
-    magickload_formats = %w[arw cr2 crw dng nef nrw orf pef raf rw2 srw]
+    magickload_formats = %w[arw cr2 crw dng nef nrw orf pef raf srw]
+    # magickload_formats = %w[arw cr2 crw dng nef nrw orf pef raf srw rw2 x3f gpr]
     image_extension(file_name).in? magickload_formats
   end
 

--- a/photo-review-client/src/components/PhotoUpload.vue
+++ b/photo-review-client/src/components/PhotoUpload.vue
@@ -137,7 +137,7 @@ const closeUploadPhoto = () => {
 // upload progress
 interface Upload {
   name: string,
-  progress: number,
+  progress: number
 }
 
 const uploads = ref([] as Upload[]);

--- a/photo-review-client/src/views/Album.vue
+++ b/photo-review-client/src/views/Album.vue
@@ -56,9 +56,6 @@
           <font-awesome-icon icon="fa-solid fa-plus" class="m-auto text-violet-600"/>
         </div>
         <div v-for="(photo, i) in photos" :key="i" class="relative cursor-pointer">
-          <!-- <RouterLink :to="{ name: 'Photo', params: { id: photo.id } }"
-            class="photo-container flex justify-center"
-          > -->
           <div class="photo-container flex justify-center cursor-pointer" @click="showPhoto(photo.id)">
             <AdvancedImage :cldImg="getCloudinaryImage(photo.image, photo.angle)"
               :id="photo.image" class="object-cover"
@@ -208,7 +205,8 @@ const removePhoto = (photoId: number) => {
 }
 const addPhoto = (photos: [Photo]) => {
   photos.forEach(photo => {
-    photosData.value.unshift(photo);
+    // photosData.value.unshift(photo);
+    photosData.value.push(photo);
   });
 }
 


### PR DESCRIPTION
![image](https://github.com/tuoanhnt95/Photo-review/assets/102507273/03e7a65e-788c-48c6-b947-a536e68b86ae)
- Show progress bar which increments  until all the files' processing is completed.
- Note: DO NOT use computed value to get the files in progress (any file with progress less than 100). I tried this approach for 2 weeks and could not debug. Tried to trigger with watch deep, check that the filter() method works on the correct array, use two computed values to track value progress of each object in the upload array. It is not worth trying to debug when this approach on upload array works.
- To-do: show each file after completed right away behind the upload progress menu, not wait until finish. Make progress bar more obvious that it is still loading (contrast, stripe style, etc.)