### PR TITLE
feat: validate input type

### DIFF
--- a/photo-review-api/app/controllers/photos_controller.rb
+++ b/photo-review-api/app/controllers/photos_controller.rb
@@ -31,6 +31,9 @@ class PhotosController < ApplicationController
     results = []
 
     photo_params[:files].each do |file|
+      # whitelist file types
+      next unless whitelist_file_types.include?(file.original_filename.split('.').last.downcase)
+
       upload = create_new_upload(file.original_filename)
 
       processed_image = ImageProcessor.call(file, photo_params[:upload_option], upload.id)
@@ -68,6 +71,10 @@ class PhotosController < ApplicationController
   end
 
   private
+
+  def whitelist_file_types
+    %w[arw bmp cr2 crw dng heic jpg jpeg nef nrw orf pef png raf srw tif tiff]
+  end
 
   def create_new_upload(file_name)
     Upload.create({

--- a/photo-review-api/app/controllers/photos_controller.rb
+++ b/photo-review-api/app/controllers/photos_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
+require './lib/modules/file_input.rb'
 
 # Photos controller
 class PhotosController < ApplicationController
+  include FileInput
   before_action :set_photo, only: %i[show update destroy]
   before_action :set_album, only: %i[index create create_new_upload]
   skip_before_action :verify_authenticity_token
@@ -32,12 +34,14 @@ class PhotosController < ApplicationController
 
     photo_params[:files].each do |file|
       # whitelist file types
-      next unless whitelist_file_types.include?(file.original_filename.split('.').last.downcase)
+      return render(json: { error: 'Invalid file type.' }, status: :unprocessable_entity) unless check_file_type_whitelist!(file.original_filename, file.content_type)
+    end
 
-      upload = create_new_upload(file.original_filename)
+    photo_params[:files].each do |file|
+      upload = create_new_upload(file)
 
       processed_image = ImageProcessor.call(file, photo_params[:upload_option], upload.id)
-      photo = make_new_photo(processed_image)
+      photo = Photo.make_new_photo(processed_image, photo_params[:album_id])
       if photo.save
         results.push(photo)
         upload.update(progress: 100)
@@ -72,13 +76,10 @@ class PhotosController < ApplicationController
 
   private
 
-  def whitelist_file_types
-    %w[arw bmp cr2 crw dng heic jpg jpeg nef nrw orf pef png raf srw tif tiff]
-  end
-
-  def create_new_upload(file_name)
+  def create_new_upload(file)
     Upload.create({
-                    name: file_name,
+                    name: file.original_filename,
+                    file_type: file.content_type,
                     progress: 15,
                     batch: @album.last_upload_batch,
                     album_id: photo_params[:album_id]
@@ -112,28 +113,6 @@ class PhotosController < ApplicationController
 
   def reviews_all_no?(values)
     values.all?(&:zero?)
-  end
-
-  def save_photos_to_db(processed_images)
-    result = []
-    processed_images.each do |img|
-      photo = make_new_photo(img)
-      if photo.save
-        result.push(photo)
-      else
-        render json: photo.errors, status: :unprocessable_entity
-      end
-    end
-    result
-  end
-
-  def make_new_photo(img)
-    Photo.new({
-                name: img[:img_name],
-                image: img[:img_url],
-                angle: 0,
-                album_id: photo_params[:album_id]
-              })
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/photo-review-api/app/models/photo.rb
+++ b/photo-review-api/app/models/photo.rb
@@ -5,6 +5,15 @@ class Photo < ApplicationRecord
 
   validates :album_id, presence: true
   validates :image, presence: true
+
+  def self.make_new_photo(img, album_id)
+    Photo.new({
+                name: img[:img_name],
+                image: img[:img_url],
+                angle: 0,
+                album_id: album_id
+              })
+  end
 end
 
 # has_one_attached :image

--- a/photo-review-api/app/services/image_processor.rb
+++ b/photo-review-api/app/services/image_processor.rb
@@ -95,7 +95,7 @@ class ImageProcessor < ApplicationService
   end
 
   def image_uses_magicload(file_name)
-    magickload_formats = %w[arw cr2 crw dng nef nrw orf pef raf srw]
+    magickload_formats = %w[arw cr2 crw dng heic nef nrw orf pef raf srw]
     # magickload_formats = %w[arw cr2 crw dng nef nrw orf pef raf srw rw2 x3f gpr]
     image_extension(file_name).in? magickload_formats
   end

--- a/photo-review-api/db/migrate/20230912141053_create_uploads.rb
+++ b/photo-review-api/db/migrate/20230912141053_create_uploads.rb
@@ -5,6 +5,7 @@ class CreateUploads < ActiveRecord::Migration[7.0]
   def change
     create_table :uploads do |t|
       t.string :name
+      t.string :file_type
       t.integer :progress
       t.integer :batch
       t.references :album, null: false, foreign_key: true

--- a/photo-review-api/db/schema.rb
+++ b/photo-review-api/db/schema.rb
@@ -82,6 +82,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_12_141053) do
 
   create_table "uploads", force: :cascade do |t|
     t.string "name"
+    t.string "file_type"
     t.integer "progress"
     t.integer "batch"
     t.bigint "album_id", null: false

--- a/photo-review-api/db/seeds.rb
+++ b/photo-review-api/db/seeds.rb
@@ -66,7 +66,7 @@ Photo.create([
                },
                {
                  name: 'Sony-a6000-Shotkit',
-                 image: 'g6u80uqgthixbrpwmkxd',
+                 image: 'rmsuqgcmfkqm6vfetfd0',
                  angle: 0,
                  album_id: Album.all[1].id
                },

--- a/photo-review-api/lib/modules/file_input.rb
+++ b/photo-review-api/lib/modules/file_input.rb
@@ -1,0 +1,25 @@
+module FileInput
+  # extend ActiveSupport::Concern
+
+  def get_file_extension(file_name)
+    file_name.split('.').last.downcase
+  end
+
+  def file_extension_whitelist
+    %w[arw bmp cr2 crw dng heic jpg jpeg nef nrw orf pef png raf srw tif tiff]
+  end
+
+  def file_type_whitelist
+    %w[image/jpeg image/png image/tiff image/bmp image/x-canon-cr2 image/x-canon-crw image/x-dcraw image/x-adobe-dng image/x-fuji-raf image/x-nikon-nef image/x-nikon-nrw image/x-olympus-orf image/x-panasonic-raw image/x-pentax-pef image/x-sony-arw image/x-sony-srw image/heic image/ARW image/BMP image/CR2 image/CRW image/DNG image/HEIC image/JPG image/JPEG image/NEF image/NRW image/ORF image/PEF image/PNG image/RAF image/SRW image/TIF image/TIFF];
+  end
+
+  def check_file_type_whitelist!(file_name, file_type)
+    # if file has extension, check if it's in whitelist
+    if file_name.include?('.')
+      return file_extension_whitelist.include?(get_file_extension(file_name))
+    else
+      # if file has no extension, check if its mime type is in whitelist
+      file_type.in?(file_type_whitelist)
+    end
+  end
+end

--- a/photo-review-client/src/main.ts
+++ b/photo-review-client/src/main.ts
@@ -12,10 +12,10 @@ import { library } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
 /* import specific icons */
-import { faPlus, faX, faHouse, faBell, faGear, faUser, faPen, faCalendarDays, faFloppyDisk, faCheck, faXmark, faQuestion, faCaretRight, faCaretLeft, faArrowLeft, faExclamation, faRotateLeft, faGripLines } from '@fortawesome/free-solid-svg-icons'
+import { faPlus, faX, faHouse, faBell, faGear, faUser, faPen, faCalendarDays, faFloppyDisk, faCheck, faXmark, faQuestion, faCaretRight, faCaretLeft, faCaretDown, faArrowLeft, faExclamation, faRotateLeft, faGripLines } from '@fortawesome/free-solid-svg-icons'
 
 /* add icons to the library */
-library.add(faPlus, faX, faHouse, faBell, faGear, faUser, faPen, faCalendarDays, faFloppyDisk, faCheck, faXmark, faQuestion, faCaretRight, faCaretLeft, faArrowLeft, faExclamation, faRotateLeft, faGripLines)
+library.add(faPlus, faX, faHouse, faBell, faGear, faUser, faPen, faCalendarDays, faFloppyDisk, faCheck, faXmark, faQuestion, faCaretRight, faCaretLeft, faCaretDown, faArrowLeft, faExclamation, faRotateLeft, faGripLines)
 
 const app = createApp(App)
 


### PR DESCRIPTION
- Whitelist all file extensions and mime types in both frontend and backend using 3 levels.
- Frontend: 
1. Filter file type with html. This reduce but does not eliminate user selecting invalid file.
2. If user selects multiple files, check if all of them are valid. If one file is not valid, user cannot upload the whole batch.

- Backend:
3. Check files' extensions and mime type against whitelist.

To-do: test files with no extension with mime type and without mime type. The check logic is in the code, but not tested.